### PR TITLE
Specify [version] for projects in make file.

### DIFF
--- a/drupal.make
+++ b/drupal.make
@@ -19,22 +19,22 @@ defaults[projects][subdir] = contrib
 
 ; Modules.
 ; --------
-projects[admin_menu] = 3.0-rc4
-projects[coder] = 2.3
-projects[devel] = 1.5
-projects[entity] = 1.5
-projects[entityreference] = 1.1
-projects[features] = 2.2
-projects[features_extra] = 1.0-beta1
-projects[fences] = 1.0
-projects[field_group] = 1.4
-projects[master] = 2.0-beta3
-projects[panels] = 3.4
-projects[pathauto] = 1.2
-projects[strongarm] = 2.0
-projects[views] = 3.8
+projects[admin_menu][version] = 3.0-rc4
+projects[coder][version] = 2.3
+projects[devel][version] = 1.5
+projects[entity][version] = 1.5
+projects[entityreference][version] = 1.1
+projects[features][version] = 2.2
+projects[features_extra][version] = 1.0-beta1
+projects[fences][version] = 1.0
+projects[field_group][version] = 1.4
+projects[master][version] = 2.0-beta3
+projects[panels][version] = 3.4
+projects[pathauto][version] = 1.2
+projects[strongarm][version] = 2.0
+projects[views][version] = 3.8
 
 
 ; Themes.
 ; --------
-projects[aurora] = 3.4
+projects[aurora][version] = 3.4


### PR DESCRIPTION
I ran into a tricky issue on a project where I was using `projects[project_name] = 1.0` syntax and then added `projects[project_name][patch][] = "path/to/patch"` below it. The line with the patch overrode the line with the version number causing the version number to be automatically determined. Using this longer syntax avoids that issue.